### PR TITLE
Changed parameter expansion to support more than 2 drives

### DIFF
--- a/get_options.sh
+++ b/get_options.sh
@@ -194,7 +194,7 @@ while getopts "han:b:r:l:i:p:v:d:f:c:R:s:z:x:gkK:t:" OPTION ; do
     # e.g.: sda,sdb | sda
     d)
       OPT_DRIVES=$OPTARG
-      sel_drives="${OPT_DRIVES/,/ }"
+      sel_drives="${OPT_DRIVES//,/ }"
       i=1
       for optdrive in $sel_drives ; do
         eval OPT_DRIVE$i="$optdrive"


### PR DESCRIPTION
There is an issue with the change added here:
https://github.com/hetzneronline/installimage/commit/489e0027d126d9287cf427a3824861ce87fd6fb0#diff-380c2d60f258a04bfc3e500ec2e28169L188

It substitutes only first comma now.
If we pass more than 2 drives, like `sda,sdb,sdc,sdd`, we get something like that:
```
OPT_DRIVE1=sda
OPT_DRIVE2=sdb,sdc,sdd
```

The fix changes it to substitute all commas.