### PR TITLE
Fix spelling of openSUSE

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -1581,7 +1581,7 @@ create_partitions() {
   # write standard entries to fstab
   echo "proc /proc proc defaults 0 0" > "$FOLD/fstab"
   # add fstab entries for devpts, sys and shm in CentOS as they are not
-  # automatically mounted by init skripts like in Debian/Ubuntu and OpenSUSE
+  # automatically mounted by init skripts like in Debian/Ubuntu and openSUSE
   if [ "$IAM" = "centos" ]; then
     {
       echo "devpts /dev/pts devpts gid=5,mode=620 0 0"
@@ -3632,7 +3632,7 @@ function part_test_size() {
   DRIVE_SIZE=$(( DRIVE_SIZE / 1024 / 1024 ))
 
   if [ "$DRIVE_SIZE" -ge $LIMIT ] || [ "$FORCE_GPT" = "1" ]; then
-    # use only GPT if not CentOS or OpenSuSE newer than 12.2
+    # use only GPT if not CentOS or openSUSE newer than 12.2
     if [ "$IAM" != "centos" ] || [ "$IAM" == "centos" -a "$IMG_VERSION" -ge 70 -a "$IMG_VERSION" != 610 ]; then
       if [ "$IAM" = "suse" ] && [ "$IMG_VERSION" -lt 122 ]; then
         echo "SuSE older than 12.2. cannot use GPT (but drive size is bigger then 2TB)" | debugoutput
@@ -3859,7 +3859,7 @@ fix_eth_naming() {
 
 
 suse_netdev_fix() {
-# device naming in OpenSuSE 12.3 for multiple NICs is
+# device naming in openSUSE 12.3 for multiple NICs is
 # currently broken. (kernel and systemd disagree with each other)
 # Workaround is to map the NICs to their own namespace (net0 instead of eth0)
 # until the fix is released

--- a/robot.sh
+++ b/robot.sh
@@ -15,7 +15,7 @@ done
 # and CentOS has also os-release
 #if [ -f /etc/os-release ]; then
 if [ -f /etc/SuSE-release ]; then
-  # openSuSE
+  # openSUSE
   sed -i -e "s#^bash /robot.*##" /etc/init.d/after.local
   sed -i -e "s#^bash /robot.*##" /etc/init.d/boot.local
 else

--- a/suse.sh
+++ b/suse.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# OpenSUSE specific functions
+# openSUSE specific functions
 #
 # (c) 2007-2018, Hetzner Online GmbH
 #
@@ -161,7 +161,7 @@ generate_new_ramdisk() {
 
 setup_cpufreq() {
   if [ -n "$1" ]; then
-     # openSuSE defaults to the ondemand governor, so we don't need to set this at all
+     # openSUSE defaults to the ondemand governor, so we don't need to set this at all
      # http://doc.opensuse.org/documentation/html/openSUSE/opensuse-tuning/cha.tuning.power.html
      # check release notes of furture releases carefully, if this has changed!
 
@@ -204,7 +204,7 @@ generate_config_grub() {
     grub_linux_default+=' pci=nommconf'
   fi
 
-  # set net.ifnames=0 to avoid predictable interface names for opensuse 13.2
+  # set net.ifnames=0 to avoid predictable interface names for openSUSE 13.2
   if [ "$IMG_VERSION" -ge 132 ] ; then
     grub_linux_default="${grub_linux_default} net.ifnames=0 quiet systemd.show_status=1"
   fi
@@ -224,7 +224,7 @@ generate_config_grub() {
 
   execute_chroot_command "grub2-mkconfig -o /boot/grub2/grub.cfg 2>&1"
 
-  # the opensuse mkinitrd uses this file to determine where to write the bootloader...
+  # the openSUSE mkinitrd uses this file to determine where to write the bootloader...
   local grubinstalldev_file; grubinstalldev_file="$FOLD/hdd/etc/default/grub_installdevice"
   rm -f "$grubinstalldev_file"
   for ((i=1; i<=COUNT_DRIVES; i++)); do


### PR DESCRIPTION
Fix #17
The correct spelling of openSUSE can be checked on https://en.opensuse.org/Portal:Distribution