### PR TITLE
Add support for installation with full disk encryption

### DIFF
--- a/debian.sh
+++ b/debian.sh
@@ -302,4 +302,8 @@ debian_udev_finish_service_fix() {
   } > "${override_file}"
 }
 
+install_initramfs_dropbear() {
+  debian_install_initramfs_dropbear
+}
+
 # vim: ai:ts=2:sw=2:et

--- a/functions.sh
+++ b/functions.sh
@@ -1997,7 +1997,7 @@ make_lvm() {
       debug "# Creating PV $pv"
       wipefs -af $pv |& debugoutput
       if [ -n "${LVM_VG_LUKS[${i}]}" ]; then
-        crypt_pv="${pv#/dev/}_crypt"
+        crypt_pv="crypt$(echo ${pv} | tr / _)"
         debug "# Creating encrypted PV $pv"
         cryptsetup luksClose /dev/mapper/$crypt_pv &> /dev/null
         echo -n "$LUKS_PASSWORD" | cryptsetup luksFormat $pv -d -  2>&1 | debugoutput
@@ -2015,7 +2015,7 @@ make_lvm() {
         pv=${dev[${LVM_VG_PART[${i}]}]}
       else
         disk=${dev[${LVM_VG_PART[${i}]}]}
-        pv="/dev/mapper/${disk#/dev/}_crypt"
+        pv="/dev/mapper/crypt$(echo ${disk} | tr / _)"
       fi
 
       # extend the VG if a VG with the same name already exists

--- a/functions.sh
+++ b/functions.sh
@@ -3979,7 +3979,7 @@ debian_install_initramfs_dropbear() {
   curl --silent --output "$FOLD/hdd/etc/initramfs-tools/scripts/init-premount/zz-hetzner-fix-routes" "https://gist.githubusercontent.com/overlordtm/b4ea42af162df528be60c0fb1193415f/raw/979772a17a694d9f9e9455b662b6b11a73bbc855/zz-hetzner-fix-routes" || return 1
   chmod +x "$FOLD/hdd/etc/initramfs-tools/scripts/init-premount/zz-hetzner-fix-routes" || return 1
   # install dropbear-initramfs
-  execute_command "apt-get --assume-yes install dropbear-initramfs" || return 1
+  execute_command "apt-get --assume-yes install dropbear-initramfs cryptsetup-initramfs" || return 1
   
   # configure dropbear
   sed -i '/^#DROPBEAR_OPTIONS=/a DROPBEAR_OPTIONS="-s -j -k -I 60 -p 54321"' "$FOLD/hdd/etc/dropbear-initramfs/config" || return 1

--- a/install.sh
+++ b/install.sh
@@ -371,10 +371,12 @@ if [ "$SWRAID" = "1" ]; then
   status_done
 fi
 
-status_busy_nostep "  Generating ramdisk"
-debug "# Generating ramdisk"
-generate_new_ramdisk "NIL" || status_failed
-status_done
+if [ "$FDE_SSH_UNLOCK" != "1" ]; then
+  status_busy_nostep "  Generating ramdisk"
+  debug "# Generating ramdisk"
+  generate_new_ramdisk "NIL" || status_failed
+  status_done
+fi
 
 status_busy_nostep "  Generating ntp config"
 debug "# Generating ntp config"
@@ -447,6 +449,18 @@ if [ "$OPT_USE_SSHKEYS" = "1" ] ; then
     debug "# Adding public SSH keys"
     copy_ssh_keys
     status_donefailed $?
+fi
+
+if [ "$FDE_SSH_UNLOCK" = "1" ]; then
+    status_busy_nostep "  Installing dropbear-initramfs"
+    debug "# Installing dropbear-initramfs"
+    install_initramfs_dropbear
+    status_donefailed $?
+
+    status_busy_nostep "  Generating ramdisk"
+    debug "# Generating ramdisk"
+    generate_new_ramdisk "NIL" || status_failed
+    status_done
 fi
 
 #

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -364,4 +364,8 @@ ubuntu_grub_fix() {
   rm "$tempfile"
 }
 
+install_initramfs_dropbear() {
+  debian_install_initramfs_dropbear
+}
+
 # vim: ai:ts=2:sw=2:et


### PR DESCRIPTION
It is not yet finished, but opening PR if you have any feedback, because there is not much information in repository on "how to contribute" :)

PR contains changes needed to create server with encrypted root partition i.e. LVM on LUKS

You can specify `lvm+luks` value filesystem in `PART`

```
LUKS_PASSWORD test
FDE_SSH_UNLOCK 1 # set to 1 to enable remote unlock via SSH
PART /boot ext3 1G
PART lvm+luks   vg0   all
```

So far tested on Ubuntu 18.04 image on hCloud VM. If FDE_SSH_UNLOCK is set to 1, dropbear SSH server is started at port 54321 after boot and waits for connections. Password login is disabled, by default all SSH keys set for root user are also copied to dropbear.