### PR TITLE
functions.sh: Replace 'which' with 'type'

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -1458,7 +1458,7 @@ stop_lvm_raid() {
 
   dmsetup remove_all > /dev/null 2>&1
 
-  test -x "$(which mdadm)" && for i in $(cat /proc/mdstat | grep md | cut -d ' ' -f1); do
+  test -x "$(type -P mdadm)" && for i in $(cat /proc/mdstat | grep md | cut -d ' ' -f1); do
     [ -e /dev/$i ] && mdadm -S /dev/$i >> /dev/null 2>&1
   done
 }


### PR DESCRIPTION
It is possible to have no `which` installed on server. It is installed as a separate package.
Better practice is to use `type` builtin. With -P option it works almost the same as `which`:
```
      -P        force a PATH search for each NAME, even if it is an alias,
                builtin, or function, and returns the name of the disk file
                that would be executed
```