### PR TITLE
Easy Dropbear support for full disk encryption at rest.

### DIFF
--- a/archlinux.sh
+++ b/archlinux.sh
@@ -264,4 +264,12 @@ run_os_specific_functions() {
   :
 }
 
+#
+# Stub for crypt dropbear support.
+# See debian_install_crypt_dropbear() in functions.sh
+#
+install_crypt_dropbear() {
+  return 1
+}
+
 # vim: ai:ts=2:sw=2:et

--- a/centos.sh
+++ b/centos.sh
@@ -421,4 +421,12 @@ run_os_specific_functions() {
   return 0
 }
 
+#
+# Stub for crypt dropbear support.
+# See debian_install_crypt_dropbear() in functions.sh
+#
+install_crypt_dropbear() {
+  return 1
+}
+
 # vim: ai:ts=2:sw=2:et

--- a/coreos.sh
+++ b/coreos.sh
@@ -368,4 +368,12 @@ run_os_specific_functions() {
   return 0
 }
 
+#
+# Stub for crypt dropbear support.
+# See debian_install_crypt_dropbear() in functions.sh
+#
+install_crypt_dropbear() {
+  return 1
+}
+
 # vim: ai:ts=2:sw=2:et

--- a/debian.sh
+++ b/debian.sh
@@ -312,4 +312,8 @@ debian_udev_finish_service_fix() {
   } > "${override_file}"
 }
 
+install_crypt_dropbear() {
+  debian_install_crypt_dropbear
+}
+
 # vim: ai:ts=2:sw=2:et

--- a/functions.sh
+++ b/functions.sh
@@ -4396,7 +4396,7 @@ EOF
   execute_command "apt-get --assume-yes update" || return 1
   execute_command "apt-get --assume-yes --ignore-missing install dropbear-initramfs cryptsetup-initramfs" || return 1
   # Configure dropbear.
-  sed -i '/^#DROPBEAR_OPTIONS=/a DROPBEAR_OPTIONS="-s -j -k -I 60 -p $CRYPTDROPBEARPORT"' "$FOLD/hdd/etc/dropbear-initramfs/config" || return 1
+  sed -i "/^#DROPBEAR_OPTIONS=/a DROPBEAR_OPTIONS=\"-s -j -k -I 60 -p ${CRYPTDROPBEARPORT}\"" "$FOLD/hdd/etc/dropbear-initramfs/config" || return 1
 }
 
 # vim: ai:ts=2:sw=2:et

--- a/functions.sh
+++ b/functions.sh
@@ -749,7 +749,9 @@ if [ -n "$1" ]; then
   CRYPTDROPBEAR="$(grep -m1 -e ^CRYPTDROPBEAR "$1" |awk '{print $2}')"
   export CRYPTDROPBEAR
   CRYPTDROPBEARPORT="$(grep -m1 -e ^CRYPTDROPBEARPORT "$1" |awk '{print $2}')"
-  [ "$CRYPTDROPBEARPORT" = "" ] && CRYPTDROPBEARPORT="22"
+  if [ "$CRYPTDROPBEARPORT" = "" ]; then
+    CRYPTDROPBEARPORT="22"
+  fi
   export CRYPTDROPBEARPORT
 
   # get LVM volume group config

--- a/install.sh
+++ b/install.sh
@@ -392,16 +392,10 @@ if [ "$SWRAID" = "1" ]; then
   status_done
 fi
 
-status_busy_nostep "  Generating ramdisk"
-debug "# Generating ramdisk"
-generate_new_ramdisk "NIL" || status_failed
-status_done
-
 status_busy_nostep "  Generating ntp config"
 debug "# Generating ntp config"
 generate_ntp_config "NIL" || status_failed
 status_done
-
 
 
 #
@@ -414,7 +408,6 @@ setup_cpufreq "$GOVERNOR" || {
 #  exit 1
 }
 #status_donefailed $?
-
 
 
 #
@@ -469,6 +462,24 @@ if [ "$OPT_USE_SSHKEYS" = "1" ] ; then
     copy_ssh_keys
     status_donefailed $?
 fi
+
+#
+# Install Dropbear for encrypted setups.
+#
+if [ "$CRYPTDROPBEAR" = "1" ]; then
+    status_busy_nostep "  Installing dropbear-initramfs"
+    debug "# Installing dropbear-initramfs"
+    install_crypt_dropbear
+    status_donefailed $?
+fi
+
+#
+# Generate ramdisk. Do this after dropbear as it also must update initramfs anyway.
+#
+status_busy_nostep "  Generating ramdisk"
+debug "# Generating ramdisk"
+generate_new_ramdisk "NIL" || status_failed
+status_done
 
 #
 # Write Bootloader

--- a/suse.sh
+++ b/suse.sh
@@ -263,4 +263,12 @@ run_os_specific_functions() {
   return 0
 }
 
+#
+# Stub for crypt dropbear support.
+# See debian_install_crypt_dropbear() in functions.sh
+#
+install_crypt_dropbear() {
+  return 1
+}
+
 # vim: ai:ts=2:sw=2:et

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -390,4 +390,8 @@ ubuntu_grub_fix() {
   rm "$tempfile"
 }
 
+install_crypt_dropbear() {
+  debian_install_crypt_dropbear
+}
+
 # vim: ai:ts=2:sw=2:et


### PR DESCRIPTION
Based on recent full disk encryption support (CRYPT setting) added in https://github.com/hetzneronline/installimage/commit/5589fd2a2eda5a4cae87bf63707e641d6a09e5b6

Effort to help solve https://github.com/hetzneronline/installimage/issues/37 with additions from https://github.com/hetzneronline/installimage/pull/21 to provide remote SSH unlock of encryption using Dropbear.

* Hetzner Root and Cloud servers work.
* Ubuntu, Debian supported.
* Function stubs ready for Arch, Centos, Coreos, Suse.

Other contributors can fill out the stub for their alternative OS. I do not use Arch, etc. on servers, so it is out of scope of my contribution.

## Quickstart for Ubuntu 20.04

Set a public SSH key in Key Management area for your Rescue system before you begin. This is the key Dropbear will use to authenticate you.

#### SSH into server.
```bash
git clone --single-branch --branch crypt_dropbear https://github.com/gnat/installimage.git
alias installimage='/root/installimage/installimage'
nano autosetup
```

#### Content of autosetup.
```bash
# Encryption.
CRYPT 1
CRYPTPASSWORD test-password
CRYPTDROPBEAR 1
# Optionally specify CRYPTDROPBEARPORT
# Drives.
DRIVE1 /dev/nvme0n1
DRIVE2 /dev/nvme1n1
# RAID mirror.
SWRAID 1
SWRAIDLEVEL 1
# Other.
BOOTLOADER grub
HOSTNAME test-host
# Partitions.
PART /boot ext3 2G
PART lvm   vg0  all crypt
# Logical Volumes.
LV vg0 tmp  /tmp      ext4  16G
LV vg0 log  /var/log  ext4  16G
LV vg0 swap swap      swap  32G
LV vg0 root /         ext4  all
# Install image.
IMAGE /root/.oldroot/nfs/install/../images/Ubuntu-2004-focal-64-minimal.tar.gz
```

#### Begin installation.
```bash
installimage -c /root/autosetup -f yes -a
```

#### After reboot run cryptroot-unlock to unlock your disk.

Enjoy and please merge! This contribution is public domain.