### PR TITLE
Removed double negation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -406,7 +406,7 @@ if [ "$OPT_USE_SSHKEYS" = "1" -a -z "$FORCE_PASSWORD" ]; then
   status_busy_nostep "  Disabling root password"
   set_rootpassword "$FOLD/hdd/etc/shadow" "*"
   status_donefailed $?
-  status_busy_nostep "  Disabling SSH root login without password"
+  status_busy_nostep "  Disabling SSH root login with password"
   set_ssh_rootlogin "without-password"
   status_donefailed $?
 else


### PR DESCRIPTION
Clarified that ssh's PermitRootLogin without-password only prohibits password login and not password-less methods like PKA.

The previous phrasing makes it sound as if after removing the root password in the previous step and disabling logins without password one would be locked out of sshing into root.