### PR TITLE
Fix creation of subvolumes nested in a directory

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -2507,6 +2507,7 @@ create_btrfs_subvolumes() {
           mp="${BTRFS_SV_MOUNT[$i]}"
           if [ "$pv" == "$vol" ]; then
             debug "creating btrfs subvolume $vol/$sv at $mp on $dev"
+            mkdir -p "$(dirname "$tmp_mount/$sv")"
             btrfs subvolume create "$tmp_mount/$sv" |& debugoutput
             entry="$dev $mp btrfs defaults,subvol=$sv 0 0\n"
             entries="$entries$entry"


### PR DESCRIPTION
This is the example subvolume configuration the user will see in the editor to uncomment or adapt to their own liking.

    SUBVOL btrfs.1  @           /
    SUBVOL btrfs.1  @/usr       /usr

Now consider this slightly modified configuration.

    SUBVOL btrfs.1  @           /
    SUBVOL btrfs.1  @/var/log   /var/log

This modified configuration is failing with the following error.

    [14:27:16] creating btrfs subvolume btrfs.1/@/var/log at /var/log on /dev/sda1
    [14:27:16] :   ERROR: cannot access '/tmp/btrfs.MaLyd/btrfs.1/@/var': No such file or directory

The problem being that the btrfs subvolume create command expects the parent directory of the subvolume to exist. This commit adds a mkdir command to create the parent directory.

I tested this on a fresh Hetzner machine in rescue mode by copying the `/root/.oldroot/nfs/install/` directory to a writeable location, adding the mkdir line and pointing the `installimage` shell alias to the new location.