### PR TITLE
Add configurable raid chunk size

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -345,9 +345,9 @@ create_config() {
         echo "SWRAIDLEVEL $set_level"
       } >> "$CNF"
 	  
-	  echo '' >> "$CNF"
+      echo '' >> "$CNF"
 	  	  
-	  {
+      {
         echo "## Choose the RAID chunk size for the /home partition"
         echo "## < 64 | 128 | 256 | 512 | 1024 | 2048 >"
         echo ""
@@ -2267,7 +2267,7 @@ make_swraid() {
         elif [ "$(echo "$line" | grep "/boot/efi")" ]; then
           array_raidlevel="1"
           array_metadata="--metadata=1.0"
-		elif [ "$(echo "$line" | grep "/home")" ] && [ "$SWRAIDLEVEL" != "1" ]; then
+        elif [ "$(echo "$line" | grep "/home")" ] && [ "$SWRAIDLEVEL" != "1" ]; then
           array_chunks="--chunk $SWRAIDCHUNKS"
         fi
 


### PR DESCRIPTION
@asciiprod My previous PR was too specific and could not be configured. I have created a new pull request. This PR allows the user to configure the raid chunk size of their `/home` partition. It will work on any raid level except for 1 which doesn't have chunk sizes. The user can choose one of the following values: `< 64 | 128 | 256 | 512 | 1024 | 2048 >`. The default is 512KB.

This pull request is inspired by the fact I'm storing large files on my Hetzner SX series dedicated root server. I want to be able to configure the raid chunk size to optimize hard-disk performance for this situation. The default 512KB chunk size is not optimal.