### PR TITLE
Make installer able to handle /dev/disk/by-id/ devices

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -2206,8 +2206,11 @@ make_swraid() {
         local n=0
         for n in $(seq 1 $COUNT_DRIVES) ; do
           TARGETDISK="$(eval echo \$DRIVE${n})"
-          local p="$(echo $TARGETDISK | grep nvme)"
-          [ -n "$p" ] && p='p'
+          local p=""
+          local nvme="$(echo $TARGETDISK | grep nvme)"
+          [ -n "$nvme" ] && p='p'
+          local disk_by_id="$(echo $TARGETDISK | grep 'disk/by-id')"
+          [ -n "$disk_by_id" ] && p='-part'
           components="$components $TARGETDISK$p$PARTNUM"
         done
 


### PR DESCRIPTION
This change introduces the detection of `DRIVEn /dev/disk/by-id/xxxx` devices.
Additionally to the different nvme naming for partitions, those disks get a `-partx` added to the device - instead of a single number

Currently the installer simply adds a "1", "2",... to the device - which is fine for `/dev/sda`, `/dev/sdb`,* - there is already a exception for nvme devices, which also needs to be implemented for `/dev/disk/by-id/*` devices.
Not having this ability to provide static device names renders the installer to become unpredictable with 3 drives if only two of them should be configured.
This change also allows devices to be listed with their `wwm-0x5xxxx` name as they also reside in `/dev/disk/by-id`.
