### PR TITLE
Fix syntax errors with custom installs

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -1653,7 +1653,10 @@ whoami() {
  fi
 
  IMG_VERSION="$(echo "$1" | cut -d "-" -f 2)"
- [ -z "$IMG_VERSION" -o "$IMG_VERSION" = "" -o "$IMG_VERSION" = "h.net.tar.gz" -o "$IMG_VERSION" = 'latest' ] && IMG_VERSION="0"
+ if [[ ("$IMG_VERSION" == *"tar"*) || ("$IMG_VERSION" == "") || ("$IMG_VERSION" = "latest") ]]; then
+   IMG_VERSION=0
+ fi
+ 
  IMG_ARCH="$(echo "$1" | sed 's/.*-\(32\|64\)-.*/\1/')"
 
  IMG_FULLNAME="$(find "$IMAGESPATH" -maxdepth 1 -type f -name "$1*" -a -not -regex '.*\.sig$' -printf '%f\n')"
@@ -3438,7 +3441,12 @@ generate_ntp_config() {
   local debian_version=0
   local ubuntu_version=0
   local suse_version=0
-  [ "$IAM" == debian ] && debian_version=$(cut -c 1 "$FOLD/hdd/etc/debian_version")
+  
+  local debfile="$FOLD/hdd/etc/debian_version"
+  if [ "$IAM" = 'debian' ] && [ -f "$debfile" ]; then
+    debian_version=$(cut -c 1 "$debfile")
+  fi
+  
   [ "$IAM" = 'ubuntu' ] && ubuntu_version="$IMG_VERSION"
   [ "$IAM" = 'suse' ] && suse_version="$IMG_VERSION"
 


### PR DESCRIPTION
This commit gracefully fixes syntax errors for custom installations. It allows the install image script to continue as expected. 

1) Fixed a bug with image version string. If the image file doesn't have a version, gracefully set it to 0. 
2) Fixed a bug with the debian_version file not being present. If it doesn't exist, gracefully set the debian version to 0.

I tested this on my hetzner dedicated server inside the rescue system. It works as expected. I created a testing environment to successfully do this.

**Side Note:** `cut -d "-" -f 2` will not cut anything, if the image file doesn't contain a version. I checked for the `tar` keyword to determine this. I used a wildcard that will work more frequently. Checking `h.net.tar.gz` is no longer required.