### PR TITLE
Add support for /dev/disk/by-id/.... notation in config

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -2323,10 +2323,10 @@ make_swraid() {
         continue
       elif [ -n "$(echo "$line" | grep "/boot")" -a  "$metadata_boot" == "--metadata=0.90" ] || [ "$metadata" == "--metadata=0.90" ]; then
         # update fstab - replace /dev/sdaX with /dev/mdY
-        echo $line | sed "s/$SEDHDD\(p\)\?[0-9]\+/\/dev\/md$md_count/g" >> $fstab
+        echo $line | sed "s/$SEDHDD\(p\|-part\)\?[0-9]\+/\/dev\/md$md_count/g" >> $fstab
       else
         # update fstab - replace /dev/sdaX with /dev/md/Y
-        echo $line | sed "s/$SEDHDD\(p\)\?[0-9]\+/\/dev\/md\/$md_count/g" >> $fstab
+        echo $line | sed "s/$SEDHDD\(p\|-part\)\?[0-9]\+/\/dev\/md\/$md_count/g" >> $fstab
       fi
 
       # create raid array

--- a/functions.sh
+++ b/functions.sh
@@ -2337,8 +2337,11 @@ make_swraid() {
         local n=0
         for n in $(seq 1 $COUNT_DRIVES) ; do
           TARGETDISK="$(eval echo \$DRIVE${n})"
-          local p="$(echo $TARGETDISK | grep nvme)"
-          [ -n "$p" ] && p='p'
+          local p=""
+          local nvme="$(echo $TARGETDISK | grep nvme)"
+          [ -n "$nvme" ] && p='p'
+          local disk_by_id="$(echo $TARGETDISK | grep 'disk/by-id')"
+          [ -n "$disk_by_id" ] && p='-part'
           components="$components $TARGETDISK$p$PARTNUM"
         done
 


### PR DESCRIPTION
Replaces https://github.com/hetzneronline/installimage/pull/56
Relates to https://github.com/hetzneronline/installimage/issues/30

Couple of remarks:
This script has multiple places where drives and partitions are handled. Almost all of them need to be aware of the 
correct notation of partitions.
I think, that most of the time it is just a lucky hit, that it works. 
Also the part where it either uses `p` (nvme) or `-part` is in there at least twice, so parts of that script have been compatible with the `by-id` notation already.

I do not feel comfortable doing that kind of refactoring, though. Just wanted to mention that it might be a good idea to pull partition detection by name (or something) together some place.

Either way, I think this is a good start.