### PR TITLE
Use the currently default system editor instead of mcedit

### DIFF
--- a/autosetup.sh
+++ b/autosetup.sh
@@ -43,7 +43,7 @@ while [ "$VALIDATED" = "false" ]; do
    VALIDATED="true"
  else
    debug "=> FAILED"
-   mcedit "$FOLD/install.conf"
+   editor "$FOLD/install.conf"
  fi
 done
 

--- a/setup.sh
+++ b/setup.sh
@@ -50,7 +50,7 @@ if [ "$OPT_AUTOMODE" ] ; then
       debug "=> FAILED"
       # dont show editor in automode. print to stdout
       echo "Abort: invalid config or parameters. See $DEBUGFILE for details"
-      # mcedit "$FOLD/install.conf"
+      # editor "$FOLD/install.conf"
       exit 1
     fi
   done
@@ -156,9 +156,9 @@ else
     VALIDATED="false"
     CANCELLED="false"
     while [ "$VALIDATED" = "false" ]; do
-      debug "# starting mcedit..."
+      debug "# starting editor..."
       whoami "$IMAGENAME"
-      mcedit "$FOLD/install.conf"; EXITCODE=$?
+      editor "$FOLD/install.conf"; EXITCODE=$?
       [ $EXITCODE != 0 ] && debug "=> FAILED"
       debug "# validating vars..."
       validate_vars "$FOLD/install.conf"; EXITCODE=$?


### PR DESCRIPTION
The user should have the possibility to use an editor that he likes and not be forced to use `mcedit`.
On the rescue system _(or other Debian/Ubuntu's)_  `editor` is `/usr/bin/editor` and a symlink to the current default editor.
The user can easily change this `update-alternatives --config editor` if he likes another editor better.