### PR TITLE
Fix disk encryption

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -826,7 +826,7 @@ if [ -n "$1" ]; then
     if [ "${PART_MOUNT[$i]}" = "/" ]; then
       HASROOT="true"
     fi
-    test -n "${PART_CRYPT[$i]}"; CRYPT=$((1 - $?))
+    [[ -n "${PART_CRYPT[$i]}" ]] && CRYPT="1"
   done < /tmp/part_lines.tmp
 
   # get encryption password


### PR DESCRIPTION
If the last `PART` line in the installimage config doesn't include the `crypt` keyword, whereas other `PART` entries have it, no partition will get encrypted.